### PR TITLE
Fixed broken ffdshow integration

### DIFF
--- a/avs_core/core/PluginManager.cpp
+++ b/avs_core/core/PluginManager.cpp
@@ -187,9 +187,9 @@ AVSFunction::AVSFunction(const char* _name, const char* _plugin_basename, const 
         param_types[len] = 0;
     }
 
-    if ( (NULL != _name) && (NULL != _plugin_basename) )
+    if ( NULL != _name )
     {
-        std::string cn(_plugin_basename);
+		std::string cn(NULL != _plugin_basename ? _plugin_basename : "");
         cn.append("_").append(_name);
         canon_name = new char[cn.size()+1];
         memcpy(canon_name, cn.c_str(), cn.size());


### PR DESCRIPTION
Integration of global functions via env->AddFunction() was broken after [that commit](https://github.com/AviSynth/AviSynthPlus/commit/ec72100460f7ad5eb7ed22c599a20fe44a154805), thus making for ffdshow impossible to add "ffdshow_source()" function.