### PR TITLE
Should use strcmp for comparison

### DIFF
--- a/avs_core/core/avisynth.cpp
+++ b/avs_core/core/avisynth.cpp
@@ -974,7 +974,7 @@ void __stdcall ScriptEnvironment::ParallelJob(ThreadWorkerFuncPtr jobFunc, void*
 void __stdcall ScriptEnvironment::SetFilterMTMode(const char* filter, MtMode mode, bool force)
 {
   assert(NULL != filter);
-  assert("" != filter);
+  assert(strcmp("", filter) != 0);
 
   std::string name_to_register;
   std::string loading = plugin_manager->PluginLoading();


### PR DESCRIPTION
The way SetFilterMTMode is checking for an empty string will always be true. Should be using strcmp to compare two c strings.