### PR TITLE
[WIP] avisynth_c: add 16-bit and 32-bit formats to match C++ interface

### DIFF
--- a/avs_core/core/avisynth_c.cpp
+++ b/avs_core/core/avisynth_c.cpp
@@ -63,6 +63,38 @@ int AVSC_CC avs_is_y8(const AVS_VideoInfo * p)
   { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_Y8    & AVS_CS_PLANAR_FILTER); }
 
 extern "C"
+int AVSC_CC avs_is_yuv444p16(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV444P16 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv422p16(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV422P16 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv420p16(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV420P16 & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_y16(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_Y16   & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv444ps(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV444PS & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv422ps(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV422PS & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_yuv420ps(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_YUV420PS & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
+int AVSC_CC avs_is_y32(const AVS_VideoInfo * p)
+  { return (p->pixel_type & AVS_CS_PLANAR_MASK) == (AVS_CS_Y32   & AVS_CS_PLANAR_FILTER); }
+
+extern "C"
 int AVSC_CC avs_is_color_space(const AVS_VideoInfo * p, int c_space)
 {
   return avs_is_planar(p) ?

--- a/avs_core/include/avisynth_c.h
+++ b/avs_core/include/avisynth_c.h
@@ -122,7 +122,29 @@ enum {
   AVS_CS_IYUV  = AVS_CS_I420,
   AVS_CS_YV411 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_4,  // YVU 4:1:1 planar
   AVS_CS_YUV9  = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_4 | AVS_CS_SUB_WIDTH_4,  // YVU 4:1:0 planar
-  AVS_CS_Y8    = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8                                              // Y   4:0:0 planar
+  AVS_CS_Y8    = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_8,                                              // Y   4:0:0 planar
+
+  //-------------------------
+  // AVS16: new planar constants go live! Experimental PF 160613
+  AVS_CS_YUV444P16 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_16 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_1, // YUV 4:4:4 16bit samples
+  AVS_CS_YUV422P16 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_16 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:2 16bit samples
+  AVS_CS_YUV420P16 = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_16 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_2 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:0 16bit samples
+  // no short naming style. AVS_CS_YV24->AVS_CS_YV48 = AVS_CS_YUV444P16 ok. but YV12->YV24? no-no.
+
+  // grey 16
+  AVS_CS_Y16 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_16,                                      // Y   4:0:0 16bit samples
+
+  // 32 bit samples (float)
+  AVS_CS_YUV444PS = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_32 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_1, // YUV 4:4:4 32bit samples
+  AVS_CS_YUV422PS = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_32 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_1 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:2 32bit samples
+  AVS_CS_YUV420PS = AVS_CS_PLANAR | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_32 | AVS_CS_VPLANEFIRST | AVS_CS_SUB_HEIGHT_2 | AVS_CS_SUB_WIDTH_2, // YUV 4:2:0 32bit samples
+  // AVS_CS_YV96  = AVS_CS_YUV444PS,
+
+  // grey 32
+  AVS_CS_Y32 = AVS_CS_PLANAR | AVS_CS_INTERLEAVED | AVS_CS_YUV | AVS_CS_SAMPLE_BITS_32                                      // Y   4:0:0 32bit samples
+
+  // todo: rgb
+
 };
 
 enum {
@@ -267,6 +289,22 @@ AVSC_API(int, avs_is_yv12)(const AVS_VideoInfo * p) ;
 AVSC_API(int, avs_is_yv411)(const AVS_VideoInfo * p);
 
 AVSC_API(int, avs_is_y8)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv444p16)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv422p16)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv420p16)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_y16)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv444ps)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv422ps)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_yuv420ps)(const AVS_VideoInfo * p);
+
+AVSC_API(int, avs_is_y32)(const AVS_VideoInfo * p);
 
 AVSC_INLINE int avs_is_property(const AVS_VideoInfo * p, int property) 
         { return ((p->image_type & property)==property ); }
@@ -761,6 +799,14 @@ struct AVS_Library {
   AVSC_DECLARE_FUNC(avs_is_yv12);
   AVSC_DECLARE_FUNC(avs_is_yv411);
   AVSC_DECLARE_FUNC(avs_is_y8);
+  AVSC_DECLARE_FUNC(avs_is_yuv444p16);
+  AVSC_DECLARE_FUNC(avs_is_yuv422p16);
+  AVSC_DECLARE_FUNC(avs_is_yuv420p16);
+  AVSC_DECLARE_FUNC(avs_is_y16);
+  AVSC_DECLARE_FUNC(avs_is_yuv444ps);
+  AVSC_DECLARE_FUNC(avs_is_yuv422ps);
+  AVSC_DECLARE_FUNC(avs_is_yuv420ps);
+  AVSC_DECLARE_FUNC(avs_is_y32);
   AVSC_DECLARE_FUNC(avs_is_color_space);
 
   AVSC_DECLARE_FUNC(avs_get_plane_width_subsampling);
@@ -840,6 +886,14 @@ AVSC_INLINE AVS_Library * avs_load_library() {
   AVSC_LOAD_FUNC(avs_is_yv12);
   AVSC_LOAD_FUNC(avs_is_yv411);
   AVSC_LOAD_FUNC(avs_is_y8);
+  AVSC_LOAD_FUNC(avs_is_yuv444p16);
+  AVSC_LOAD_FUNC(avs_is_yuv422p16);
+  AVSC_LOAD_FUNC(avs_is_yuv420p16);
+  AVSC_LOAD_FUNC(avs_is_y16);
+  AVSC_LOAD_FUNC(avs_is_yuv444ps);
+  AVSC_LOAD_FUNC(avs_is_yuv422ps);
+  AVSC_LOAD_FUNC(avs_is_yuv420ps);
+  AVSC_LOAD_FUNC(avs_is_y32);
   AVSC_LOAD_FUNC(avs_is_color_space);
 
   AVSC_LOAD_FUNC(avs_get_plane_width_subsampling);


### PR DESCRIPTION
This is a pseudo-test in order to hash out the correct pathways for supporting >8bit in FFmpeg's AviSynth demuxer, which uses the C interface.

The patch needed for FFmpeg is also 'ready', in that the skeleton of the existing formats (minus the floating point ones; FFmpeg doesn't have any pix_fmts for floating point video) is there in the patch, but they won't want to commit several patches as additional formats show up in a relatively short timeframe.  So I won't submit the patch to them until RGB and 10-/12-/14-bit are added.

Here are the corresponding test builds of AviSynth+, FFmpeg, and mpv:
http://www.mediafire.com/download/k7e2tb1yavu05tr/ffmpeg_r80789_avshbd.7z
http://www.mediafire.com/download/rsfawx6jjpd07tu/mpv_r43454_avshbd.7z
http://www.mediafire.com/download/cv9c9a817434b8e/avisynth__r1885-g8e9acf1-20160627_hbd.7z