### PR TITLE
BitsPerPixel fix

### DIFF
--- a/avs_core/core/interface.cpp
+++ b/avs_core/core/interface.cpp
@@ -252,7 +252,7 @@ int VideoInfo::BitsPerPixel() const {
     if (IsPlanar()) {
       const int componentSizes[8] = {1,2,4,0,0,2,2,2};
       const int S = (IsYUV() || IsYUVA()) ? GetPlaneWidthSubsampling(PLANAR_U) + GetPlaneHeightSubsampling(PLANAR_U) : 0;
-      return ( ((1<<S)+2) * (componentSizes[(pixel_type>>CS_Shift_Sample_Bits) & 7]) ) >> S;
+      return ( ((1<<S)+2) * (componentSizes[(pixel_type>>CS_Shift_Sample_Bits) & 7]) * 8 ) >> S;
     }
     return 0;
 }

--- a/plugins/ConvertStacked/ConvertStacked.cpp
+++ b/plugins/ConvertStacked/ConvertStacked.cpp
@@ -168,7 +168,7 @@ public:
             vi.pixel_type = VideoInfo::CS_YUV444P16;
         else if (bits == 16 && vi.IsY8())
             vi.pixel_type = VideoInfo::CS_Y16;
-        else env->ThrowError("ConvertStackedToNative: Input stacked clip must be YV12, YV16, YV24 or Y8");
+        else env->ThrowError("ConvertFromStacked: Input stacked clip must be YV12, YV16, YV24 or Y8");
 
         vi.height = vi.height >> 1; // div 2 non stacked
 


### PR DESCRIPTION
With this, BitsPerPixel actually returns *bits* for planar formats (which was the source of the problem I was encountering), and not bytes.

Also fix that errant reference to ConvertStackedToNative I mentioned before.