### PR TITLE
DirectShowSource: Sensible defaults for CMake baseclasses lib, removed dx include path

### DIFF
--- a/plugins/DirectShowSource/CMakeLists.txt
+++ b/plugins/DirectShowSource/CMakeLists.txt
@@ -5,10 +5,17 @@ CMAKE_MINIMUM_REQUIRED( VERSION 2.8.11 )
 set(PluginName "DirectShowSource")
 set(ProjectName "Plugin${PluginName}")
 
+# Sensible defaults that should just work if WINSDK is installed and baseclasses built
+set(DEFAULT_BASECLASSES_PATH "C:/Program Files/Microsoft SDKs/Windows/v7.1/Samples/multimedia/directshow/baseclasses")
+if(CMAKE_SIZEOF_VOID_P EQUAL 4) # 32-bit
+  set(DEFAULT_BASECLASSES_LIB "${DEFAULT_BASECLASSES_PATH}/Release/strmbase.lib")
+else() # 64-bit
+  set(DEFAULT_BASECLASSES_LIB "${DEFAULT_BASECLASSES_PATH}/x64/Release/strmbase.lib")
+endif()
+
 # We need these variables set by the user to compile successfully
-set(DSHOWSRC_BASECLASSES_PATH "C:/Program Files/Microsoft SDKs/Windows/v7.1/Samples/multimedia/directshow/baseclasses" CACHE STRING "Folder path to the DirectShow example baseclasses.")
-set(DSHOWSRC_BASECLASSES_LIB CACHE FILEPATH "File path to the DirectShow example baseclasses precompiled static library ('strmbase.lib').")
-set(DSHOWSRC_DX_INCLUDE_PATH "C:/Program Files/Microsoft DirectX SDK (August 2009)/Include" CACHE STRING "Include folder path to the DirectX headers.")
+set(DSHOWSRC_BASECLASSES_PATH "${DEFAULT_BASECLASSES_PATH}" CACHE STRING   "Folder path to the DirectShow example baseclasses.")
+set(DSHOWSRC_BASECLASSES_LIB  "${DEFAULT_BASECLASSES_LIB}"  CACHE FILEPATH "File path to the DirectShow example baseclasses precompiled static library ('strmbase.lib').")
 
 # Create library
 project(${ProjectName})
@@ -23,7 +30,7 @@ set_target_properties(${ProjectName} PROPERTIES "OUTPUT_NAME" ${PluginName})
 target_link_libraries(${ProjectName} "Winmm.lib" "Quartz.lib" "Ole32.lib" "User32.lib" "Oleaut32.lib" "Advapi32.lib" ${DSHOWSRC_BASECLASSES_LIB})
 
 # Include directories
-target_include_directories(${ProjectName} PRIVATE ${AvsCore_SOURCE_DIR} ${DSHOWSRC_BASECLASSES_PATH} ${DSHOWSRC_DX_INCLUDE_PATH})
+target_include_directories(${ProjectName} PRIVATE ${AvsCore_SOURCE_DIR} ${DSHOWSRC_BASECLASSES_PATH})
 
 if (MSVC_IDE)    
   # Copy output to a common folder for easy deployment


### PR DESCRIPTION
It seems to me that the DX includes are not needed to build DirectShowSource (dshow headers are in the platform sdk, not in dx).
Also added defaults for baseclasses lib in case you just build it in it's original location. I don't know if it's OK or not like this, ideas?

Also this brought up an issue that was probably there before: CMake configure needs to be run twice for CMAKE_GENERATOR_TOOLSET to take effect. If you configure only once and open the solution, the projects will have "vs140" toolset instead of "vs140_xp". If you hit configure again, it gets fixed.
The only report of this I found was here, but no solution:
http://stackoverflow.com/questions/25302502/have-cmake-select-msvc-platform-toolset-explicitly
